### PR TITLE
added proxy configuration to route backend requests in dev env

### DIFF
--- a/kum-archaeodb-web/angular.json
+++ b/kum-archaeodb-web/angular.json
@@ -68,7 +68,8 @@
               "browserTarget": "kum-archaeodb-web:build:production"
             },
             "development": {
-              "browserTarget": "kum-archaeodb-web:build:development"
+              "browserTarget": "kum-archaeodb-web:build:development",
+              "proxyConfig": "proxy.conf.json"
             }
           },
           "defaultConfiguration": "development"

--- a/kum-archaeodb-web/proxy.conf.json
+++ b/kum-archaeodb-web/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+    "/api": {
+        "target": "http://localhost:8080",
+        "secure": false
+    }
+}


### PR DESCRIPTION
With this configuration you can start Spring Boot application (default port 8080 is assumed), then start Angular app with `ng serve` and all requests to _/api/*_ will be automatically routed to the backend.

So, we don't need cross-origin requests and you can use relative links in frontend. Production setup will be similar (nginx serving frontend and proxying /api/* and authorization requests)