### PR TITLE
added support for custom column separators in CSV

### DIFF
--- a/kum-archaeodb-service/src/main/java/ua/kuzjka/kumarchaeo/parsing/ItemListParser.java
+++ b/kum-archaeodb-service/src/main/java/ua/kuzjka/kumarchaeo/parsing/ItemListParser.java
@@ -68,28 +68,62 @@ public class ItemListParser {
         mapperCommasSeparator = new CsvMapper().registerModule(new CommaFloatJacksonModule());
     }
 
+    /**
+     * Parses CSV item list and auto-detects item properties, using tab as a column separator and period as
+     * a decimal fraction separator
+     * @param in            CSV contents
+     * @return              List of parsed items
+     * @throws IOException  If an exception occurs while reading or parsing the content
+     */
     public List<ItemParsingDto> parseCsv(InputStream in) throws IOException {
-        return parseCsv(in, false);
+        return parseCsv(in, '\t', false);
     }
 
+    /**
+     * Parses CSV item list and auto-detects item properties, using tab as a column separator and period as
+     * a decimal fraction separator
+     * @param str           CSV contents
+     * @return              List of parsed items
+     * @throws IOException  If an exception occurs while reading or parsing the content
+     */
     public List<ItemParsingDto> parseCsv(String str) throws IOException {
-        return parseCsv(str, false);
+        return parseCsv(str, '\t', false);
     }
 
-    public List<ItemParsingDto> parseCsv(InputStream in, boolean commaDecimalSeparators) throws IOException {
+    /**
+     * Parses CSV item list and auto-detects item properties.
+     * @param in                        CSV contents
+     * @param columnSeparator           Column separator character
+     * @param commaDecimalSeparators    Set to {@code true} if comma is used as a decimal separator
+     * @return                          List of parsed items
+     * @throws IOException              If an exception occurs while reading or parsing the content
+     */
+    public List<ItemParsingDto> parseCsv(InputStream in, char columnSeparator, boolean commaDecimalSeparators) throws IOException {
         ObjectMapper mapper = commaDecimalSeparators ? this.mapperCommasSeparator : this.mapper;
 
-        try (MappingIterator<ItemListEntry> it = mapper.readerFor(ItemListEntry.class).with(schema).readValues(in)) {
+        try (MappingIterator<ItemListEntry> it = mapper.readerFor(ItemListEntry.class)
+                .with(schema.withColumnSeparator(columnSeparator))
+                .readValues(in)) {
             List<ItemListEntry> entries = it.readAll();
 
             return entries.stream().map(this::parseItem).filter(Objects::nonNull).collect(Collectors.toList());
         }
     }
 
-    public List<ItemParsingDto> parseCsv(String str, boolean commaDecimalSeparators) throws IOException {
+    /**
+     * Parses CSV item list and auto-detects item properties.
+     * @param str                       CSV contents
+     * @param columnSeparator           Column separator character
+     * @param commaDecimalSeparators    Set to {@code true} if comma is used as a decimal separator
+     * @return                          List of parsed items
+     * @throws IOException              If an exception occurs while reading or parsing the content
+     */
+    public List<ItemParsingDto> parseCsv(String str, char columnSeparator, boolean commaDecimalSeparators) throws IOException {
         ObjectMapper mapper = commaDecimalSeparators ? this.mapperCommasSeparator : this.mapper;
 
-        try (MappingIterator<ItemListEntry> it = mapper.readerFor(ItemListEntry.class).with(schema).readValues(str)) {
+        try (MappingIterator<ItemListEntry> it = mapper.readerFor(ItemListEntry.class)
+                .with(schema.withColumnSeparator(columnSeparator))
+                .readValues(str)) {
             List<ItemListEntry> entries = it.readAll();
 
             return entries.stream().map(this::parseItem).filter(Objects::nonNull).collect(Collectors.toList());

--- a/kum-archaeodb-service/src/test/java/ua/kuzjka/kumarchaeo/parsing/ItemListParserTest.java
+++ b/kum-archaeodb-service/src/test/java/ua/kuzjka/kumarchaeo/parsing/ItemListParserTest.java
@@ -46,7 +46,7 @@ public class ItemListParserTest {
         when(itemRepository.findByPointNumber(any())).thenReturn(Optional.empty());
 
         InputStream in = getClass().getResourceAsStream("itemList.csv");
-        List<ItemParsingDto> items = parser.parseCsv(in, true);
+        List<ItemParsingDto> items = parser.parseCsv(in, '\t', true);
 
         assertEquals(6, items.size());
         ItemParsingDto item;
@@ -169,19 +169,38 @@ public class ItemListParserTest {
     }
 
     @Test
+    public void testCustomColumnSeparator() throws IOException {
+        String content = "268;Куля св з зал хвоста розплющена;22х17х6;11;;;7,048307;81,145097;705;;Трикутний ліс";
+
+        when(itemRepository.findByPointNumber(any())).thenReturn(Optional.empty());
+
+        List<ItemParsingDto> items = parser.parseCsv(content, ';', true);
+
+        assertEquals(1, items.size());
+
+        ItemParsingDto item = items.get(0);
+
+        assertEquals(268, item.getNumber().getNumber());
+        assertEquals("Куля св з зал хвоста розплющена", item.getName());
+        assertEquals("22х17х6", item.getDimensions());
+        assertEquals(11, item.getWeight(), 0.1f);
+        assertEquals(7.048307f, item.getLocation().getLatitude(), 0.000001f);
+        assertEquals(81.145097f, item.getLocation().getLongitude(), 0.000001f);
+        assertEquals("705", item.getGpsPoint());
+    }
+
+    @Test
     public void testParseExistingNumber() throws IOException {
         when(itemRepository.findByPointNumber(any())).thenReturn(Optional.of(new Item()));
 
         InputStream in = getClass().getResourceAsStream("itemList.csv");
-        List<ItemParsingDto> items = parser.parseCsv(in, true);
+        List<ItemParsingDto> items = parser.parseCsv(in, '\t', true);
 
         assertEquals(6, items.size());
 
         assertTrue(items.stream().noneMatch(ItemParsingDto::isSave));
         assertTrue(items.stream().allMatch(ItemParsingDto::isNumberExists));
     }
-
-
 
     @Test
     public void testAutodetectCategory() {


### PR DESCRIPTION
Please check out this change.

`CsvSchema#withColumnSeparator(char)` returns new schema unless the passed argument is the same as current separator. So, we should be safe in sense of multi-threaded environment.